### PR TITLE
Buffer Starvation when buffer is smaller than demand

### DIFF
--- a/lib/rtp_jitter_buffer.ex
+++ b/lib/rtp_jitter_buffer.ex
@@ -68,7 +68,7 @@ defmodule Membrane.Element.RTP.JitterBuffer do
         if buffer_full?(state) do
           retrieve_buffer(state)
         else
-          {:ok, state}
+          {{:ok, redemand: :output}, state}
         end
 
       {:error, _reason} ->

--- a/test/rtp_jitter_buffer/pipeline_test.exs
+++ b/test/rtp_jitter_buffer/pipeline_test.exs
@@ -5,10 +5,10 @@ defmodule Membrane.Element.RTP.JitterBuffer.PipelineTest do
   alias Membrane.Test.BufferFactory
   alias Membrane.Element.RTP.JitterBuffer, as: RTPJitterBuffer
 
-  @last_number 100
+  @last_number 1000
 
   test "Jitter Buffer works in a Pipeline" do
-    buffer_size = 10
+    buffer_size = 100
 
     {:ok, pipeline} =
       Testing.Pipeline.start_link(%Testing.Pipeline.Options{

--- a/test/rtp_jitter_buffer/rtp_jitter_buffer_test.exs
+++ b/test/rtp_jitter_buffer/rtp_jitter_buffer_test.exs
@@ -19,7 +19,9 @@ defmodule Membrane.Element.RTP.JitterBufferTest do
 
   describe "When new packet comes Jitter Buffer" do
     test "adds that packet to buffer when it comes on time", %{state: state, buffer: buffer} do
-      assert {:ok, state} = RTPJitterBuffer.handle_process(:input, buffer, nil, state)
+      assert {{:ok, redemand: :output}, state} =
+               RTPJitterBuffer.handle_process(:input, buffer, nil, state)
+
       assert %RTPJitterBuffer.State{store: store} = state
       assert {:ok, {%BufferStore.Record{buffer: ^buffer}, _}} = BufferStore.get_next_buffer(store)
     end


### PR DESCRIPTION
# Description
When Jitter Buffer size is smaller than demand it starves halting pipeline.

# Testing
Currently pipeline test works on rather small buffer of 10 buffers. I've increased size to 100 to reproduce the issue.

# Proposed fix
When buffer is not filled redemand is sent.